### PR TITLE
Logging

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -61,7 +61,6 @@ my $builder = $class->new(
           'YAML::XS'                     => 0,
           'XML::LibXML'                  => 0,
 
-          'npg_common::roles::log'                             => 0,
           'npg_common::roles::software_location'               => 0,
           'npg_qc::autoqc::qc_store'                           => 0,
           'npg_tracking::data::reference::find'                => 0,

--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 LIST OF CHANGES
 ---------------
 
+ - Replaced the original log role with the one from DNAP utilities, which provides
+   a Log4perl logger and some convenience methods. All the original log statements
+   were at the same "level", no ethey are split into INFO, WARN and ERROR. Replaced
+   croak with logcroak. '--verbose' mode activates DEBUG level.
+
  - support generation of targeted stats files in seq_alignment.pm with p4
  - qc jobs creation, can_run, check object instantiation:
      do not supply path/qc_in, which is now optional

--- a/bin/create_summary_link
+++ b/bin/create_summary_link
@@ -13,10 +13,7 @@ our $VERSION = '0';
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $INFO,
-                          utf8   => 1},
-                         {layout => $layout,
-                          level  => $INFO,
-                          file   => 'STDOUT'});
+                          utf8   => 1});
 
 npg_pipeline::run::folder::link->new_with_options()->make_link({ required_job_completion => q{} });
 
@@ -26,29 +23,28 @@ __END__
 
 =head1 NAME
 
-create_summary_link
+ create_summary_link
 
 =head1 USAGE
 
-create_summary_link --run_folder=<run_folder> ( --folder=<analysis/outgoing>)
+ create_summary_link --run_folder=<run_folder>
 
 =head1 REQUIRED ARGUMENTS
 
  run_folder
 
-=head1 OPTIONS
-
- folder - this shoudl be analysis or outgoing depending on the folder which is going to be used
-
 =head1 EXIT STATUS
 
-0
+ 0
 
 =head1 CONFIGURATION
 
 =head1 SYNOPSIS
 
 =head1 DESCRIPTION
+
+ One of the scripts invoked by the analysis pipeline. Creates a soft link in the run folder,
+ which points to one of the subdirectories in the current analysis folder. 
 
 =head1 SUBROUTINES/METHODS
 
@@ -68,6 +64,8 @@ create_summary_link --run_folder=<run_folder> ( --folder=<analysis/outgoing>)
 
 =item lib
 
+=item Log::Log4perl
+
 =item npg_pipeline::run::folder::link
 
 =back
@@ -82,7 +80,7 @@ Andy Brown
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2016 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/create_summary_link
+++ b/bin/create_summary_link
@@ -33,6 +33,8 @@ __END__
 
  run_folder
 
+=head1 OPTIONS
+
 =head1 EXIT STATUS
 
  0

--- a/bin/npg_pipeline_central
+++ b/bin/npg_pipeline_central
@@ -14,7 +14,9 @@ my $p       = npg_pipeline::pluggable::harold::central->new_with_options();
 
 my $level   = $p->verbose() ? $DEBUG : $INFO;
 my $logfile = $p->log_file();
-print STDERR "Pipelile log file: ${logfile}\n";
+##no critic (InputOutput::RequireCheckedSyscalls)
+print {*STDERR} "Pipeline log file: ${logfile}\n";
+##use critic
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $level,

--- a/bin/npg_pipeline_central
+++ b/bin/npg_pipeline_central
@@ -13,10 +13,7 @@ our $VERSION = '0';
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $INFO,
-                          utf8   => 1},
-                         {layout => $layout,
-                          level  => $INFO,
-                          file   => 'STDOUT'});
+                          utf8   => 1});
 
 npg_pipeline::pluggable::harold::central->new_with_options()->main;
 
@@ -66,6 +63,8 @@ npg_pipeline_central --runfolder_path=<path> (--id_flowcell_lims=<id> --verbose 
 
 =item FindBin
 
+=item Log::Log4perl
+
 =item npg_pipeline::pluggable::harold::central
 
 =back
@@ -80,7 +79,7 @@ Guoying Qi
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2016 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/npg_pipeline_central
+++ b/bin/npg_pipeline_central
@@ -13,7 +13,7 @@ our $VERSION = '0';
 my $p       = npg_pipeline::pluggable::harold::central->new_with_options();
 
 my $level   = $p->verbose() ? $DEBUG : $INFO;
-my $logfile = $p->log_file();
+my $logfile = $p->log_file_path();
 ##no critic (InputOutput::RequireCheckedSyscalls)
 print {*STDERR} "Pipeline log file: ${logfile}\n";
 ##use critic

--- a/bin/npg_pipeline_central
+++ b/bin/npg_pipeline_central
@@ -10,12 +10,18 @@ use npg_pipeline::pluggable::harold::central;
 
 our $VERSION = '0';
 
+my $p       = npg_pipeline::pluggable::harold::central->new_with_options();
+
+my $level   = $p->verbose() ? $DEBUG : $INFO;
+my $logfile = $p->log_file();
+print STDERR "Pipelile log file: ${logfile}\n";
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
-                          level  => $INFO,
+                          level  => $level,
+                          file   => $logfile,
                           utf8   => 1});
 
-npg_pipeline::pluggable::harold::central->new_with_options()->main;
+$p->main();
 
 0;
 

--- a/bin/npg_pipeline_check_bam_file_cluster_count
+++ b/bin/npg_pipeline_check_bam_file_cluster_count
@@ -13,10 +13,7 @@ our $VERSION = '0';
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $INFO,
-                          utf8   => 1},
-                         {layout => $layout,
-                          level  => $INFO,
-                          file   => 'STDOUT'});
+                          utf8   => 1});
 
 npg_pipeline::archive::file::BamClusterCounts->new_with_options()->run_cluster_count_check();
 
@@ -32,11 +29,15 @@ npg_pipeline_check_file_cluster_count
 
 =head1 DESCRIPTION
 
-This script goes and checks pf cluster counts in BustardSummary.xml match the read counts in the bam files
+This is one of the scripts invoked by teh analysis pipeline, most likely
+as an LSF job.
+It checks pf cluster counts in BustardSummary.xml match the read counts
+in the bam files.
 
 =head1 USAGE
 
-  npg_pipeline_check_bam_file_cluster_count --id_run 1234 --position 4 --bam_basecall_path /path/to/bam_basecall --archive_path /path/to/archive/directory
+  npg_pipeline_check_bam_file_cluster_count --id_run 1234 --position 4 \
+    --bam_basecall_path /path/to/bam_basecall --archive_path /path/to/archive/directory
 
 =head1 REQUIRED ARGUMENTS
 
@@ -50,7 +51,7 @@ pathways which will eventually allow determination of bam_basecall and archive l
 
 =head1 EXIT STATUS
 
-0
+ 0
 
 =head1 SUBROUTINES/METHODS
 
@@ -70,6 +71,8 @@ pathways which will eventually allow determination of bam_basecall and archive l
 
 =item lib
 
+=item Log::Log4perl
+
 =item npg_pipeline::archive::file::BamClusterCounts
 
 =back
@@ -84,7 +87,7 @@ Guoying Qi
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2016 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/npg_pipeline_post_qc_review
+++ b/bin/npg_pipeline_post_qc_review
@@ -13,10 +13,7 @@ our $VERSION = '0';
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $INFO,
-                          utf8   => 1},
-                         {layout => $layout,
-                          level  => $INFO,
-                          file   => 'STDOUT'});
+                          utf8   => 1});
 
 npg_pipeline::pluggable::harold::post_qc_review->new_with_options()->main;
 
@@ -54,6 +51,9 @@ npg_pipeline_post_qc_review --run_folder=<run_folder> (--id_run <id_run> --verbo
 
 =head1 DESCRIPTION
 
+ Pipeline for archival of Illumina sequencing data for an individual run.
+ Creates jobs that are run under LSF.
+
 =head1 SUBROUTINES/METHODS
 
 =head1 DIAGNOSTICS
@@ -69,6 +69,8 @@ npg_pipeline_post_qc_review --run_folder=<run_folder> (--id_run <id_run> --verbo
 =item warnings
 
 =item lib
+
+=item Log::Log4perl
 
 =item FindBin
 
@@ -86,7 +88,7 @@ Andy Brown
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2016 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/npg_pipeline_post_qc_review
+++ b/bin/npg_pipeline_post_qc_review
@@ -13,7 +13,7 @@ our $VERSION = '0';
 my $p       = npg_pipeline::pluggable::harold::post_qc_review->new_with_options();
 
 my $level   = $p->verbose() ? $DEBUG : $INFO;
-my $logfile = $p->log_file();
+my $logfile = $p->log_file_path();
 ##no critic (InputOutput::RequireCheckedSyscalls)
 print {*STDERR} "Pipeline log file: ${logfile}\n";
 ##use critic

--- a/bin/npg_pipeline_post_qc_review
+++ b/bin/npg_pipeline_post_qc_review
@@ -10,12 +10,18 @@ use npg_pipeline::pluggable::harold::post_qc_review;
 
 our $VERSION = '0';
 
+my $p       = npg_pipeline::pluggable::harold::post_qc_review->new_with_options();
+
+my $level   = $p->verbose() ? $DEBUG : $INFO;
+my $logfile = $p->log_file();
+print STDERR "Pipelile log file: ${logfile}\n";
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
-                          level  => $INFO,
+                          level  => $level,
+                          file   => $logfile,
                           utf8   => 1});
 
-npg_pipeline::pluggable::harold::post_qc_review->new_with_options()->main;
+$p->main();
 
 0;
 

--- a/bin/npg_pipeline_post_qc_review
+++ b/bin/npg_pipeline_post_qc_review
@@ -14,7 +14,9 @@ my $p       = npg_pipeline::pluggable::harold::post_qc_review->new_with_options(
 
 my $level   = $p->verbose() ? $DEBUG : $INFO;
 my $logfile = $p->log_file();
-print STDERR "Pipelile log file: ${logfile}\n";
+##no critic (InputOutput::RequireCheckedSyscalls)
+print {*STDERR} "Pipeline log file: ${logfile}\n";
+##use critic
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $level,

--- a/bin/npg_pipeline_seqchksum_comparator
+++ b/bin/npg_pipeline_seqchksum_comparator
@@ -13,10 +13,7 @@ use npg_pipeline::archive::file::generation::seqchksum_comparator;
 my $layout = '%d %-5p %c - %m%n';
 Log::Log4perl->easy_init({layout => $layout,
                           level  => $INFO,
-                          utf8   => 1},
-                         {layout => $layout,
-                          level  => $INFO,
-                          file   => 'STDOUT'});
+                          utf8   => 1});
 
 npg_pipeline::archive::file::generation::seqchksum_comparator->new_with_options()->do_comparison();
 
@@ -59,7 +56,10 @@ bam_basecall_path
 
 =head1 DESCRIPTION
 
-Bamcat any plex/split bamfiles back together, perform a bamseqchksum and compare it with the one produced by the illumina2bam step, or croak if that has not been done.
+This script is run at the end of analysis pipeline, most likely as an LSF job.
+
+Bamcat any plex/split bamfiles back together, perform a bamseqchksum and compare it
+with the one produced by the illumina2bam step, or croak if that has not been done.
 
 =head1 SUBROUTINES/METHODS
 
@@ -77,6 +77,8 @@ Bamcat any plex/split bamfiles back together, perform a bamseqchksum and compare
 
 =item lib
 
+=item Log::Log4perl
+
 =item FindBin
 
 =item npg_pipeline::archive::file::seqchsksum_comparator
@@ -93,7 +95,7 @@ Kate Taylor
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2016 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/npg_pipeline/base.pm
+++ b/lib/npg_pipeline/base.pm
@@ -738,7 +738,7 @@ __END__
 
 =item MooseX::AttributeCloner
 
-=item npg_common::roles::log
+=item Log::Log4perl
 
 =item npg_tracking::illumina::run::short_info
 

--- a/lib/npg_pipeline/base.pm
+++ b/lib/npg_pipeline/base.pm
@@ -89,6 +89,8 @@ sub _update_file_appender {
       close $log or carp "Failed to close '$logfile': $ERRNO";
     }
 
+    print STDERR "Pipeline log file: ${logfile}\n";
+
     my $logging_class = $self->meta->name;
 
     my $appender = $Log::Log4perl::Logger::APPENDER_BY_NAME{$logging_class};

--- a/lib/npg_pipeline/daemon.pm
+++ b/lib/npg_pipeline/daemon.pm
@@ -11,6 +11,7 @@ use Log::Log4perl;
 use Readonly;
 use Try::Tiny;
 
+
 use npg_tracking::illumina::run::folder::location;
 use npg_tracking::illumina::run::short_info;
 use npg_tracking::util::abs_path qw/abs_path/;
@@ -22,6 +23,7 @@ use npg_pipeline::roles::business::base;
 
 with qw{ 
          MooseX::Getopt
+         WTSI::DNAP::Utilities::Loggable
          npg_pipeline::roles::accessor
        };
 
@@ -396,7 +398,7 @@ captured and printed to the log.
 
 =item List::MoreUtils
 
-=item Log::Log4perl
+=item WTSI::DNAP::Utilities::Loggable
 
 =item Readonly
 

--- a/lib/npg_pipeline/daemon/analysis.pm
+++ b/lib/npg_pipeline/daemon/analysis.pm
@@ -10,8 +10,6 @@ use npg_tracking::util::abs_path qw/abs_path/;
 
 extends qw{npg_pipeline::daemon};
 
-with qw{WTSI::DNAP::Utilities::Loggable};
-
 our $VERSION = '0';
 
 Readonly::Scalar my $PIPELINE_SCRIPT        => q{npg_pipeline_central};

--- a/lib/npg_pipeline/daemon/archival.pm
+++ b/lib/npg_pipeline/daemon/archival.pm
@@ -6,8 +6,6 @@ use Try::Tiny;
 
 extends qw{npg_pipeline::daemon};
 
-with qw{WTSI::DNAP::Utilities::Loggable};
-
 our $VERSION = '0';
 
 Readonly::Scalar our $POST_QC_REVIEW_SCRIPT => q{npg_pipeline_post_qc_review};

--- a/lib/npg_pipeline/launcher/status.pm
+++ b/lib/npg_pipeline/launcher/status.pm
@@ -53,8 +53,9 @@ sub submit {
 # responsible for generating the bsub command to be executed
 sub _generate_bsub_command {
   my ($self, $required_job_completion) = @_;
-  my $timestamp = $self->timestamp();
 
+  $required_job_completion ||= q[];
+  my $timestamp = $self->timestamp();
   my $run_folder = $self->run_folder();
   my $status     = $self->status();
   my $id_run     = $self->id_run();

--- a/lib/npg_pipeline/pluggable.pm
+++ b/lib/npg_pipeline/pluggable.pm
@@ -361,7 +361,8 @@ sub prepare {
   my $s = '***************************************************';
   $self->debug("\n" . $s);
   foreach my $name (qw/PATH CLASSPATH PERL5LIB/) {
-    $self->debug(sprintf '*** %s: %s', $name, $ENV{$name});
+    my $value = $ENV{$name} || 'Not defined';
+    $self->debug(sprintf '*** %s: %s', $name, $value);
   }
   $self->debug($s . "\n");
   return;

--- a/lib/npg_pipeline/pluggable.pm
+++ b/lib/npg_pipeline/pluggable.pm
@@ -358,14 +358,12 @@ sub schedule_functions {
 =cut
 sub prepare {
   my $self = shift;
-  if ($self->verbose) {
-    my $s = '***************************************************';
-    $self->info("\n" . $s);
-    foreach my $name (qw/PATH CLASSPATH PERL5LIB/) {
-      $self->info(sprintf '*** %s: %s', $name, $ENV{$name});
-    }
-    $self->info($s . "\n");
+  my $s = '***************************************************';
+  $self->debug("\n" . $s);
+  foreach my $name (qw/PATH CLASSPATH PERL5LIB/) {
+    $self->debug(sprintf '*** %s: %s', $name, $ENV{$name});
   }
+  $self->debug($s . "\n");
   return;
 }
 
@@ -391,7 +389,7 @@ sub main {
   };
   $self->_clear_env_vars();
   if ($error) {
-    $self->logcroak($error);
+    croak($error);
   }
   return;
 }

--- a/lib/npg_pipeline/pluggable/harold.pm
+++ b/lib/npg_pipeline/pluggable/harold.pm
@@ -65,69 +65,18 @@ Readonly::Scalar my $MIN_ARCHIVE_PATH_DEPTH => 3;
 
 =cut
 
-=head2 log_file_path
-
-Directory path for the log file, defaults to run folder path
-
-=cut
-
-has q{log_file_path} => (
+has q{_log_file_name} => (
    isa           => q{Str},
    is            => q{ro},
-   metaclass     => q{NoGetopt},
    lazy_build    => 1,
 );
-sub _build_log_file_path {
-  my $self = shift;
-  return $self->runfolder_path();
-}
-
-=head2 log_file_name
-
-Log file name, optional, will be generated if not given.
-
-=cut
-
-has q{log_file_name} => (
-   isa           => q{Str},
-   is            => q{ro},
-   metaclass     => q{NoGetopt},
-   lazy_build    => 1,
-);
-sub _build_log_file_name {
+sub _build__log_file_name {
   my $self = shift;
   my $log_name = $self->script_name . q{_} . $self->id_run();
   $log_name .= q{_} . $self->timestamp() . q{.log};
   # If $self->script_name includes a directory path, change / to _
   $log_name =~ s{/}{_}gmxs;
   return $log_name;
-}
-
-=head2
-
-Log file full path, optional, will be generated if not given.
-
-=cut
-
-has q{log_file} => (
-   isa           => q{Str},
-   is            => q{ro},
-   metaclass     => q{NoGetopt},
-   lazy_build    => 1,
-);
-sub _build_log_file {
-  my $self = shift;
-  my $logfile = catfile($self->log_file_path, $self->log_file_name);
-  if (! -d $self->log_file_path) {
-    $self->make_log_dir($self->log_file_path);
-  }
-  if (! -e $logfile) {
-    open my $log, '>', $logfile
-      or confess "Failed to open log file '$logfile' for writing: $ERRNO";
-    close $log or carp "Failed to close '$logfile': $ERRNO";
-  }
-
-  return $logfile;
 }
 
 =head2 BUILD
@@ -141,6 +90,17 @@ sub BUILD {
   $self->_inject_save2file_status_functions();
   $self->_inject_autoqc_functions();
   return;
+}
+
+=head2 log_file_path
+
+Suggested log file full path.
+
+=cut
+
+sub log_file_path {
+  my $self = shift;
+  return catfile($self->runfolder_path(), $self->_log_file_name);
 }
 
 =head2 prepare

--- a/lib/npg_pipeline/pluggable/harold/post_qc_review.pm
+++ b/lib/npg_pipeline/pluggable/harold/post_qc_review.pm
@@ -200,16 +200,14 @@ sub _update_warehouse_command {
 Copy the copy_interop_files files to iRODS
 
 =cut
-sub copy_interop_files_to_irods
-{
+sub copy_interop_files_to_irods {
   my ($self, @args) = @_;
   my $required_job_completion = shift @args;
   my $command = $self->_interop_command($required_job_completion);
   return $self->submit_bsub_command($command);
 }
 
-sub _interop_command
-{
+sub _interop_command {
   my ($self, $required_job_completion) = @_;
   my $id_run = $self->id_run;
   my $command = "irods_interop_loader.pl --id_run $id_run --runfolder_path ".$self->runfolder_path();

--- a/lib/npg_pipeline/roles/business/harold_calibration_reqs.pm
+++ b/lib/npg_pipeline/roles/business/harold_calibration_reqs.pm
@@ -5,8 +5,6 @@ use English qw{-no_match_vars};
 use Carp;
 use Readonly;
 
-with 'WTSI::DNAP::Utilities::Loggable';
-
 requires qw{directory_exists};
 
 our $VERSION = '0';
@@ -37,7 +35,6 @@ for internal running of the harold calibration steps.
 
 Note, your class must provide the following methods
 
- 'log'
  'directory_exists'
 
 =head1 SUBROUTINES/METHODS

--- a/lib/npg_pipeline/run/folder/link.pm
+++ b/lib/npg_pipeline/run/folder/link.pm
@@ -88,11 +88,10 @@ npg_pipeline::run::folder::link
 
 =head1 SYNOPSIS
 
-  my $rfl = npg_pipeline::run::folder::link->new({
+  my $rfl = npg_pipeline::run::folder::link->new(
     run_folder    => <run_folder>,
-    folder        => <analysis/outgoing>, # defaults to analysis
     analysis_path => q{Data/Intensities/Bustard_dir/GERALD_dir}, # required if you want to override any existing link
-  });
+  );
 
 =head1 DESCRIPTION
 
@@ -149,7 +148,7 @@ Andy Brown
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Ltd
+Copyright (C) 2016 Genome Research Ltd
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/t/10-base.t
+++ b/t/10-base.t
@@ -7,10 +7,15 @@ use File::Copy qw(cp);
 use Cwd;
 use Sys::Filesystem::MountPoint qw(path_to_mount_point);
 use Sys::Hostname;
+use Log::Log4perl qw(:levels);
 
 use t::util;
 use t::dbic_util;
 
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], t::util->new()->temp_directory(), 'logfile'),
+                          utf8   => 1});
 use_ok(q{npg_pipeline::base});
 
 {

--- a/t/10-pluggable.t
+++ b/t/10-pluggable.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More tests => 21;
 use Test::Exception;
 use Cwd;
+use Log::Log4perl qw(:levels);
 use t::util;
 
 local $ENV{PATH} = join q[:], q[t/bin], q[t/bin/software/solexa/bin], $ENV{PATH};
@@ -14,6 +15,11 @@ my $test_dir = $util->temp_directory();
 $ENV{TEST_DIR} = $test_dir;
 $ENV{OWNING_GROUP} = q{staff};
 local $ENV{NPG_WEBSERVICE_CACHE_DIR} = q[t/data];
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $test_dir, 'logfile'),
+                          utf8   => 1});
 
 {
   my $pluggable = npg_pipeline::pluggable->new(

--- a/t/10-pluggable_harold.t
+++ b/t/10-pluggable_harold.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More tests => 58;
 use Test::Deep;
 use Test::Exception;
+use Log::Log4perl qw(:levels);
 use t::util;
 use t::dbic_util;
 
@@ -11,8 +12,13 @@ local $ENV{http_proxy} = 'http://wibble';
 local $ENV{no_proxy}   = q[];
 
 my $util = t::util->new();
+my $tdir = $util->temp_directory();
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $tdir, 'logfile'),
+                          utf8   => 1});
 
-$ENV{TEST_DIR} = $util->temp_directory();
+$ENV{TEST_DIR} = $tdir;
 
 use_ok('npg_pipeline::pluggable::harold');
 

--- a/t/15-pipeline_launcher_scripts.t
+++ b/t/15-pipeline_launcher_scripts.t
@@ -24,7 +24,7 @@ my $bin = $curdir . q[/bin];
   my $tmp_dir = $util->temp_directory();
   local $ENV{TEST_DIR} = $tmp_dir;
 
-  my $out = `perl $bin/npg_pipeline_central --spider --no_bsub --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234 --function_order dodo`;
+  my $out = `$bin/npg_pipeline_central --spider --no_bsub --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234 --function_order dodo 2>&1`;
   like($out,
   qr/Error initializing pipeline: Error while spidering/,
   'error in spidering when pre-set samplesheet does not exist');
@@ -36,7 +36,7 @@ my $bin = $curdir . q[/bin];
   my $tmp_dir = $util->temp_directory();
   local $ENV{TEST_DIR} = $tmp_dir;
 
-  my $out = `perl $bin/npg_pipeline_central --no-spider --no_bsub --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234 --function_order dodo`;
+  my $out = `$bin/npg_pipeline_central --no-spider --no_bsub --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234 --function_order dodo 2>&1`;
   like($out,
   qr/Can't locate object method "dodo" via package "npg_pipeline::pluggable::harold::central"/,
   'error when function does not exist');
@@ -52,23 +52,23 @@ my $bin = $curdir . q[/bin];
   my $tmp_dir = $util->temp_directory();
   local $ENV{TEST_DIR} = $tmp_dir;
  
-  lives_ok { diag qx{
-    perl $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234};}
+  lives_ok { qx{
+    $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234};}
     q{ran bin/npg_pipeline_post_qc_review};
   ok(!$CHILD_ERROR, qq{Return code of $CHILD_ERROR});
 
-  lives_ok { diag qx{
-    perl $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234  --gclp}; }
+  lives_ok { qx{
+    $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234  --gclp}; }
     q{ran bin/npg_pipeline_post_qc_review with gclp flag};
   ok(!$CHILD_ERROR, qq{Return code of $CHILD_ERROR});
 
-  lives_ok { diag qx{
-    perl $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234  --function_list gclp}; }
+  lives_ok { qx{
+    $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234  --function_list gclp}; }
     q{ran bin/npg_pipeline_post_qc_review with gclp function list};
   ok(!$CHILD_ERROR, qq{Return code of $CHILD_ERROR});
 
-  lives_ok { diag qx{
-    perl $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234  --function_list some}; }
+  lives_ok { qx{
+    $bin/npg_pipeline_post_qc_review --runfolder_path $tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234  --function_list some}; }
     q{ran bin/npg_pipeline_post_qc_review with non-exisitng function list};
   ok($CHILD_ERROR, qq{Child error $CHILD_ERROR});
 }
@@ -79,7 +79,7 @@ my $bin = $curdir . q[/bin];
   my $tmp_dir = $util->temp_directory();
   local $ENV{TEST_DIR} = $tmp_dir;
 
-  lives_ok { qx{perl $bin/npg_pipeline_seqchksum_comparator --id_run=1234 --archive_path=$tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234/Data/Intensities/BAM_basecalls_20140815-114817/no_cal/archive --bam_basecall_path=$tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234/Data/Intensities/BAM_basecalls_20140815-114817 --lanes=1 };} q{ran bin/npg_pipeline_seqchksum_comparator with analysis and bam_basecall_path};
+  lives_ok { qx{$bin/npg_pipeline_seqchksum_comparator --id_run=1234 --archive_path=$tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234/Data/Intensities/BAM_basecalls_20140815-114817/no_cal/archive --bam_basecall_path=$tmp_dir/nfs/sf45/IL2/analysis/123456_IL2_1234/Data/Intensities/BAM_basecalls_20140815-114817 --lanes=1 };} q{ran bin/npg_pipeline_seqchksum_comparator with analysis and bam_basecall_path};
   ok($CHILD_ERROR, qq{Return code of $CHILD_ERROR as no files found});
 }
 

--- a/t/20-archive_file_generation-illumina2bam.t
+++ b/t/20-archive_file_generation-illumina2bam.t
@@ -6,6 +6,7 @@ use Test::Differences;
 use File::Copy;
 use File::Path qw(make_path);
 use Cwd;
+use Log::Log4perl qw(:levels);
 use t::util;
 
 my $util = t::util->new();
@@ -15,6 +16,11 @@ $ENV{TEST_FS_RESOURCE} = q{nfs_12};
 local $ENV{NPG_WEBSERVICE_CACHE_DIR} = 't/data/illumina2bam';
 local $ENV{CLASSPATH} = q{t/bin/software/solexa/bin/aligners/illumina2bam/current};
 local $ENV{PATH} = join q[:], q[t/bin], q[t/bin/software/solexa/bin], $ENV{PATH};
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $dir, 'logfile'),
+                          utf8   => 1});
 
 use_ok('npg_pipeline::archive::file::generation::illumina2bam');
 my $current = getcwd();

--- a/t/20-archive_file_generation-seq_alignment.t
+++ b/t/20-archive_file_generation-seq_alignment.t
@@ -7,6 +7,7 @@ use File::Temp qw/tempdir/;
 use Cwd qw/cwd abs_path/;
 use Perl6::Slurp;
 use File::Copy;
+use Log::Log4perl qw(:levels);
 
 use_ok('npg_pipeline::archive::file::generation::seq_alignment');
 local $ENV{'NPG_WEBSERVICE_CACHE_DIR'} = q[t/data/rna_seq];
@@ -16,6 +17,11 @@ local $ENV{CLASSPATH} = q[t/bin/software/solexa/bin/aligners/illumina2bam/curren
 
 my $odir = abs_path cwd;
 my $dir = tempdir( CLEANUP => 1);
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $dir, 'logfile'),
+                          utf8   => 1});
 
 ###12597_1    study: genomic sequencing, library type: No PCR
 ###12597_8#7  npg/run/12597.xml st/studies/2775.xml  batches/26550.xml samples/1886325.xml  <- Epigenetics, library type: qPCR only
@@ -51,9 +57,9 @@ subtest 'test 1' => sub {
   `touch $dir/references/Strongyloides_ratti/20100601/all/picard/rat.fa`;
   `mkdir -p $dir/references/Strongyloides_ratti/20100601/all/bwa0_6`;
   `touch $dir/references/Strongyloides_ratti/20100601/all/bwa0_6/rat.fa`;
-  `mkdir $ref_dir/bowtie2`;
-  `mkdir $ref_dir/picard`;
-  `mkdir $ref_dir/bwa0_6`;
+  `mkdir -p $ref_dir/bowtie2`;
+  `mkdir -p $ref_dir/picard`;
+  `mkdir -p $ref_dir/bwa0_6`;
   `touch $ref_dir/fasta/mm_ref_NCBI37_1.fasta`;
   `touch $ref_dir/bowtie2/mm_ref_NCBI37_1.fasta`;
   `touch $ref_dir/picard/mm_ref_NCBI37_1.fasta`;
@@ -216,9 +222,9 @@ subtest 'test 2' => sub {
 
   my $ref_dir = join q[/],$dir,'references','Homo_sapiens','1000Genomes_hs37d5','all';
   `mkdir -p $ref_dir/fasta`;
-  `mkdir $ref_dir/bowtie2`;
-  `mkdir $ref_dir/picard`;
-  `mkdir $ref_dir/bwa0_6`;
+  `mkdir -p $ref_dir/bowtie2`;
+  `mkdir -p $ref_dir/picard`;
+  `mkdir -p $ref_dir/bwa0_6`;
   `touch $ref_dir/fasta/hs37d5.fa`;
   `touch $ref_dir/bowtie2/hs37d5.fa`;
   `touch $ref_dir/picard/hs37d5.fa`;
@@ -230,7 +236,7 @@ subtest 'test 2' => sub {
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20140606-133530/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20140606-133530/metadata_cache_13066';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
   copy("t/data/rna_seq/13066_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!"; #to get information that it is paired end
   my $transcriptome_dir = join q[/],$dir,'transcriptomes','Homo_sapiens','ensembl_75_transcriptome','1000Genomes_hs37d5';
   `mkdir -p $transcriptome_dir/gtf`;
@@ -327,7 +333,7 @@ subtest 'test 4' => sub {
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150712-121006/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150712-121006/metadata_cache_16839';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
   copy("t/data/hiseqx/16839_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!"; #to get information that it is paired end
   `touch $ref_dir/fasta/Homo_sapiens.GRCh38_full_analysis_set_plus_decoy_hla.fa`;
   `touch $ref_dir/picard/Homo_sapiens.GRCh38_full_analysis_set_plus_decoy_hla.fa.dict`;
@@ -386,15 +392,15 @@ subtest 'test 5' => sub {
 
   my $ref_dir = join q[/],$dir,'references','Homo_sapiens','1000Genomes_hs37d5','all';
   `mkdir -p $ref_dir/fasta`;
-  `mkdir $ref_dir/bwa0_6`;
-  `mkdir $ref_dir/picard`;
+  `mkdir -p $ref_dir/bwa0_6`;
+  `mkdir -p $ref_dir/picard`;
 
   my $runfolder = q{150707_HS38_16807_A_C7U2YANXX};
   my $runfolder_path = join q[/], $dir, $runfolder;
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150707-232614/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150707-232614/metadata_cache_16807';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
   copy("t/data/hiseq/16807_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!"; #to get information that it is paired end
 
   local $ENV{'NPG_WEBSERVICE_CACHE_DIR'} = q[t/data/hiseq];
@@ -445,9 +451,9 @@ subtest 'test 6' => sub {
 
   my $ref_dir = join q[/],$dir,'references','Homo_sapiens','1000Genomes_hs37d5','all';
   `mkdir -p $ref_dir/fasta`;
-  `mkdir $ref_dir/bwa`;
-  `mkdir $ref_dir/bwa0_6`;
-  `mkdir $ref_dir/picard`;
+  `mkdir -p $ref_dir/bwa`;
+  `mkdir -p $ref_dir/bwa0_6`;
+  `mkdir -p $ref_dir/picard`;
 
   my $bait_dir = join q[/],$dir,'baits','Human_all_exon_V5','1000Genomes_hs37d5';
   `mkdir -p $bait_dir`;
@@ -459,7 +465,7 @@ subtest 'test 6' => sub {
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20160712-154117/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20160712-154117/metadata_cache_20268';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
 
   copy("t/data/hiseq/20268_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!";
 
@@ -524,15 +530,15 @@ subtest 'test 7' => sub {
 
   my $ref_dir = join q[/],$dir,'references','Plasmodium_falciparum','3D7_Oct11v3','all';
   `mkdir -p $ref_dir/fasta`;
-  `mkdir $ref_dir/bwa0_6`;
-  `mkdir $ref_dir/picard`;
+  `mkdir -p $ref_dir/bwa0_6`;
+  `mkdir -p $ref_dir/picard`;
 
   my $runfolder = q{150710_MS2_16850_A_MS3014507-500V2};
   my $runfolder_path = join q[/], $dir, $runfolder;
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150712-022206/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150712-022206/metadata_cache_16850';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
   copy("t/data/miseq/16850_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!"; #to get information that it is paired end
   `touch $ref_dir/fasta/Pf3D7_v3.fasta`;
   `touch $ref_dir/picard/Pf3D7_v3.fasta.dict`;
@@ -589,15 +595,15 @@ subtest 'test 8' => sub {
 
   my $ref_dir = join q[/],$dir,'references','Plasmodium_falciparum','3D7_Oct11v3','all';
   `mkdir -p $ref_dir/fasta`;
-  `mkdir $ref_dir/bwa0_6`;
-  `mkdir $ref_dir/picard`;
+  `mkdir -p $ref_dir/bwa0_6`;
+  `mkdir -p $ref_dir/picard`;
 
   my $runfolder = q{150701_HS36_16756_B_C711RANXX};
   my $runfolder_path = join q[/], $dir, $runfolder;
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150707-132329/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150707-132329/metadata_cache_16756';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
   copy("t/data/hiseq/16756_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!"; #to get information that it is paired end
   # default human reference needed for alignment for unconsented human split
   my $default_source = join q[/],$dir,'references','Homo_sapiens','1000Genomes_hs37d5';
@@ -656,7 +662,7 @@ subtest 'test 9' => sub {
   my $bc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150714-133929/no_cal';
   `mkdir -p $bc_path`;
   my $cache_dir = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20150714-133929/metadata_cache_16866';
-  `mkdir $cache_dir`;
+  `mkdir -p $cache_dir`;
 
   copy("t/data/miseq/16866_RunInfo.xml","$runfolder_path/RunInfo.xml") or die "Copy failed: $!"; #to get information that it is paired end
   local $ENV{'NPG_WEBSERVICE_CACHE_DIR'} = q[t/data/miseq];

--- a/t/20-archive_folder_generation.t
+++ b/t/20-archive_folder_generation.t
@@ -2,12 +2,19 @@ use strict;
 use warnings;
 use Test::More tests => 4;
 use Test::Exception;
+use Log::Log4perl qw(:levels);
 use t::util;
 
 use_ok('npg_pipeline::archive::folder::generation');
 
 my $util = t::util->new();
-$ENV{TEST_DIR} = $util->temp_directory();
+my $tdir = $util->temp_directory();
+$ENV{TEST_DIR} = $tdir;
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $tdir, 'logfile'),
+                          utf8   => 1});
 
 local $ENV{NPG_WEBSERVICE_CACHE_DIR} = 't/data';
 local $ENV{PATH} = join q[:], q[t/bin], q[t/bin/software/solexa/bin], $ENV{PATH};

--- a/t/25-analysis-FixConfigFiles.t
+++ b/t/25-analysis-FixConfigFiles.t
@@ -4,8 +4,15 @@ use Test::More tests => 11;
 use Test::Exception;
 use File::Slurp;
 use File::Temp qw{ tempdir };
+use Log::Log4perl qw(:levels);
 
 use t::dbic_util;
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], tempdir(CLEANUP => 1), 'logfile'),
+                          utf8   => 1});
+
 my $schema = t::dbic_util->new()->test_schema;
 
 use_ok( q{npg_pipeline::analysis::FixConfigFiles} );

--- a/t/25-analysis-bustard4pbcb.t
+++ b/t/25-analysis-bustard4pbcb.t
@@ -2,23 +2,24 @@ use strict;
 use warnings;
 use Test::More tests => 18;
 use Test::Exception;
+use Log::Log4perl qw(:levels);
 use t::util;
 
-use npg_pipeline::pluggable;
-
 my $util = t::util->new();
-
 my $tmp_dir = $util->temp_directory();
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $tmp_dir, 'logfile'),
+                          utf8   => 1});
+
 $ENV{TEST_DIR} = $tmp_dir;
 $ENV{TEST_FS_RESOURCE} = q{nfs_12};
 local $ENV{NPG_WEBSERVICE_CACHE_DIR} = q[t/data];
 local $ENV{PATH} = join q[:], q[t/bin], q[t/bin/software/solexa/bin], $ENV{PATH};
-
 my $mem_units = 'MB';
 
-BEGIN {
-  use_ok(q{npg_pipeline::analysis::bustard4pbcb});
-}
+use_ok(q{npg_pipeline::analysis::bustard4pbcb});
 
 my $runfolder_path = $util->analysis_runfolder_path();
 my $bustard_home   = qq{$runfolder_path/Data/Intensities};

--- a/t/25-analysis-create_lane_tag_file.t
+++ b/t/25-analysis-create_lane_tag_file.t
@@ -4,12 +4,18 @@ use Test::More tests => 56;
 use Test::Exception;
 use File::Slurp;
 use File::Temp qw(tempdir);
+use Log::Log4perl qw(:levels);
 
 use st::api::lims; 
 
+my $dir = tempdir( CLEANUP => 1 );
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $dir, 'logfile'),
+                          utf8   => 1});
 
 use_ok(q{npg_pipeline::analysis::create_lane_tag_file});
-my $dir = tempdir( CLEANUP => 1 );
 
 {
   local $ENV{NPG_WEBSERVICE_CACHE_DIR} = 't/data';

--- a/t/25-harold_calibration_bam.t
+++ b/t/25-harold_calibration_bam.t
@@ -4,6 +4,7 @@ use Test::More tests => 39;
 use Test::Exception::LessClever;
 use t::util;
 use Cwd;
+use Log::Log4perl qw(:levels);
 
 my $util = t::util->new();
 
@@ -14,6 +15,11 @@ my $tdir = $util->temp_directory();
 $ENV{TEST_DIR} = $tdir;
 $ENV{TEST_FS_RESOURCE} = q{nfs_12};
 $ENV{NPG_WEBSERVICE_CACHE_DIR} = $curdir . q{/t/data};
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $tdir, 'logfile'),
+                          utf8   => 1});
 
 my $sp = join q[/], $tdir, 'spatial_filter';
 my $java = join q[/], $tdir, 'java';
@@ -38,7 +44,7 @@ my $config_path    = qq{$runfolder_path/Config};
 sub set_staging_analysis_area {
   `rm -rf /tmp/nfs/sf45`;
   `mkdir -p $bustard_rta`;
-  `mkdir $config_path`;
+  `mkdir -p $config_path`;
   `cp t/data/Recipes/Recipe_GA2_37Cycle_PE_v6.1.xml $runfolder_path/`;
   `cp t/data/Recipes/TileLayout.xml $config_path/`;
   return 1;

--- a/t/25-harold_calibration_bam.t
+++ b/t/25-harold_calibration_bam.t
@@ -53,8 +53,6 @@ sub set_staging_analysis_area {
       run_folder => q{123456_IL2_1234},
       runfolder_path => $runfolder_path,
       timestamp => q{20091028-101635},
-      log_file_path => $runfolder_path,
-      log_file_name => q{npg_pipeline_pb_cal_20091028-101635.log},
       verbose => 0,
       repository => $repos,
       no_bsub => 1,

--- a/t/35-archive-file-generation-seqchksum_comparator.t
+++ b/t/35-archive-file-generation-seqchksum_comparator.t
@@ -2,9 +2,8 @@ use strict;
 use warnings;
 use Test::More tests => 14;
 use Test::Exception;
+use Log::Log4perl qw(:levels);
 use t::util;
-
-use_ok( q{npg_pipeline::archive::file::generation::seqchksum_comparator} );
 
 my $util = t::util->new({});
 my $tmp_dir = $util->temp_directory();
@@ -12,6 +11,13 @@ local $ENV{TEST_DIR} = $tmp_dir;
 
 local $ENV{NPG_WEBSERVICE_CACHE_DIR} = q[t/data];
 local $ENV{PATH} = join q[:], q[t/bin], q[t/bin/software/solexa/bin], $ENV{PATH};
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $tmp_dir, 'logfile'),
+                          utf8   => 1});
+
+use_ok( q{npg_pipeline::archive::file::generation::seqchksum_comparator} );
 
 $util->set_rta_staging_analysis_area();
 
@@ -66,10 +72,10 @@ all pass  19821774    3a58186f  29528f13  7bf272c0  30e0b9ef
 END1
 
   system "mkdir -p $archive_path/lane1";
-  system "cp -pv t/data/runfolder/archive/lane1/1234_1#15.cram $archive_path/lane1";
+  system "cp -p t/data/runfolder/archive/lane1/1234_1#15.cram $archive_path/lane1";
 
   system "mkdir -p $archive_path/lane2";
-  system "cp -pv t/data/runfolder/archive/lane1/1234_1#15.cram $archive_path/lane2/1234_2#15.cram";
+  system "cp -p t/data/runfolder/archive/lane1/1234_1#15.cram $archive_path/lane2/1234_2#15.cram";
 
   open my $seqchksum_fh1, '>', "$bam_basecall_path/1234_1.post_i2b.seqchksum" or die "Cannot open file for writing";
   print $seqchksum_fh1 $seqchksum_contents1 or die $!;
@@ -81,8 +87,8 @@ END1
       throws_ok{$object->do_comparison()} qr/Failed to run command bamcat /, q{Doing a comparison with empty bam files throws an exception}; 
     }
 
-    system "cp -pv t/data/seqchksum/sorted.cram $archive_path/lane1/1234_1#15.cram";
-    system "cp -pv t/data/seqchksum/sorted.cram $archive_path/lane2/1234_2#15.cram";
+    system "cp -p t/data/seqchksum/sorted.cram $archive_path/lane1/1234_1#15.cram";
+    system "cp -p t/data/seqchksum/sorted.cram $archive_path/lane2/1234_2#15.cram";
 
     throws_ok{$object->do_comparison()} qr/Found a difference in seqchksum for post_i2b and product /, q{Doing a comparison with different bam files throws an exception}; 
   }

--- a/t/50-npg_pipeline-daemon-analysis.t
+++ b/t/50-npg_pipeline-daemon-analysis.t
@@ -5,23 +5,26 @@ use Test::Exception;
 use Cwd;
 use File::Path qw{ make_path };
 use List::MoreUtils qw{ any };
-use Log::Log4perl qw{ :easy };
+use Log::Log4perl qw{ :levels };
 use English qw{ -no_match_vars };
 
 use t::util;
 use t::dbic_util;
 
-$ENV{'http_proxy'} = 'http://wibble.com'.
+$ENV{'http_proxy'} = 'http://wibble.com';
+my $util = t::util->new();
+my $temp_directory = $util->temp_directory();
 
-Log::Log4perl->easy_init($INFO);
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $temp_directory, 'logfile'),
+                          utf8   => 1});
 
 my $package = 'npg_pipeline::daemon::analysis';
 my $script_name = q[npg_pipeline_central];
 
 use_ok($package);
 
-my $util = t::util->new();
-my $temp_directory = $util->temp_directory();
 my $script = join q[/],  $temp_directory, $script_name;
 `touch $script`;
 `chmod +x $script`;

--- a/t/50-npg_pipeline-daemon-archival.t
+++ b/t/50-npg_pipeline-daemon-archival.t
@@ -4,19 +4,22 @@ use Test::More tests => 19;
 use Test::Exception;
 use Cwd;
 use List::MoreUtils qw{any};
-use Log::Log4perl qw(:easy);
+use Log::Log4perl qw(:levels);
 
 use t::dbic_util;
 use t::util;
 
-Log::Log4perl->easy_init($ERROR);
+my $util = t::util->new();
+my $temp_directory = $util->temp_directory();
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => join(q[/], $temp_directory, 'logfile'),
+                          utf8   => 1});
 
 my $script_name = q[npg_pipeline_post_qc_review];
 
 use_ok('npg_pipeline::daemon::archival');
-
-my $util = t::util->new();
-my $temp_directory = $util->temp_directory();
 
 my $script = join q[/],  $temp_directory, $script_name;
 `touch $script`;


### PR DESCRIPTION
To avoid exessive output to the pipeline's daemon log, ensures that only one log appender is created. In the pipeline scripts logging to a file is used. In other scripts (the ones executed as LSF jobs) logged content goes to STDERR; it will be saved to an output file by LSF.

Logging in tests is directed to a temporary file.

Th last pipeline croak move back to being a plain croak, we need this error to go either to a console when the pipeline is run manually, or to the daemon log when it’s launched by the pipeline daemon.

When the pipeline log file path is computed, it’s written to STDERR for the reasons mentioned in the above paragraph.
